### PR TITLE
リッチメニューを作成

### DIFF
--- a/assets/mainMenu.json
+++ b/assets/mainMenu.json
@@ -1,0 +1,63 @@
+{
+  "size": {
+    "width": 2500,
+    "height": 1688
+  },
+  "selected": true,
+  "name": "メインメニュー",
+  "chatBarText": "メインメニュー",
+  "areas": [
+    {
+      "bounds": {
+        "x": 0,
+        "y": 0,
+        "width": 2500,
+        "height": 850
+      },
+      "action": {
+        "type": "message",
+        "label": "通知の設定",
+        "text": "通知の設定"
+      }
+    },
+    {
+      "bounds": {
+        "x": 0,
+        "y": 850,
+        "width": 833,
+        "height": 836
+      },
+      "action": {
+        "type": "message",
+        "label": "不具合の報告",
+        "text": "不具合の報告"
+      }
+    },
+    {
+      "bounds": {
+        "x": 833,
+        "y": 850,
+        "width": 833,
+        "height": 836
+      },
+      "action": {
+        "type": "message",
+        "label": "開発者について",
+        "text": "開発者について"
+      }
+    },
+    {
+      "bounds": {
+        "x": 1666,
+        "y": 850,
+        "width": 833,
+        "height": 836
+      },
+      "action": {
+        "type": "message",
+        "label": "通知の解除",
+        "text": "通知の解除"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Solved Issues ✨
- Close #2 

## Changes ⚒
- リッチメニューを [リッチメニューエディタ](https://richmenu.app.e-chan.cf/) で作成
- デフォルトに設定
- JSONを書き出してmainMenu.jsonとして格納(再編集したい時のため)

## Screenshot
<img width="300" src="https://user-images.githubusercontent.com/23429049/100352542-7b4adf80-3030-11eb-8910-1bb45c4f0a07.jpeg">
