### PR TITLE
時刻のストア/検索はUTCで行う

### DIFF
--- a/src/deliverNotification/deliverNotification.ts
+++ b/src/deliverNotification/deliverNotification.ts
@@ -44,7 +44,7 @@ export default async (date?:Date)=>{
  
  const now=date||new Date()
  const db=new PostgreSQLDriver()
- const areaUsers=await db.getUsersToNotify(`${('00'+now.getHours()).slice(-2)}:${('00'+now.getMinutes()).slice(-2)}:00`)
+ const areaUsers=await db.getUsersToNotify(`${('00'+now.getUTCHours()).slice(-2)}:${('00'+now.getUTCMinutes()).slice(-2)}:00`)
  
  for(const area in  areaUsers){
   const {users}=areaUsers[area]

--- a/src/handlers/db/postgres/postgreSQLDriver.ts
+++ b/src/handlers/db/postgres/postgreSQLDriver.ts
@@ -29,8 +29,11 @@ export default class PostgreSQLDriver {
 
   // TODO: areaのvalidationも将来的に入れたい!
   
+  const h =Number(time.substring(0,2))-9%24
+  const m = Number(time.substring(3,5))
+  
   await db.query(
-   {text:"UPDATE users SET time=$1,area=$2,modify_date=current_timestamp WHERE user_id=$3",values:[time,area,userID]
+   {text:"UPDATE users SET time=$1,area=$2,modify_date=current_timestamp WHERE user_id=$3",values:[`${('00'+h).slice(-2)}:${('00'+m).slice(-2)}:00`,area,userID]
   }).catch(e=>{throw e}); 
  }
 


### PR DESCRIPTION
## Solved Issue
- ロケール時刻設定がUTCになったDockerコンテナ上で動作させると設定時刻の9時間前に通知が来てしまう(JST=UTC+9なので)

## Changes
- 時刻をストアする時に9時間引いてUTCで保存するようにする
- DBからの検索も`getUTC*` を使ってUTC基準で行う

