### PR TITLE
時間(h)が負数になることのないように修正する

### DIFF
--- a/src/handlers/db/postgres/postgreSQLDriver.ts
+++ b/src/handlers/db/postgres/postgreSQLDriver.ts
@@ -29,7 +29,7 @@ export default class PostgreSQLDriver {
 
   // TODO: areaのvalidationも将来的に入れたい!
   
-  const h =Number(time.substring(0,2))-9%24
+  const h =(Number(time.substring(0,2))-9+24)%24
   const m = Number(time.substring(3,5))
   
   await db.query(


### PR DESCRIPTION
## Solved Issues✨
- 時刻が当日の時刻の時に -3時などとなっていた問題(PostgreSQLがエラーを返す)

## Changes ⛏
- 剰余を取る前に24を足して剰余算結果が負数になることを防ぐ