### PR TITLE
ユーザがすでにいた場合のエラーは無視する

### DIFF
--- a/src/handlers/db/postgres/postgreSQLDriver.ts
+++ b/src/handlers/db/postgres/postgreSQLDriver.ts
@@ -12,8 +12,16 @@ export default class PostgreSQLDriver {
   
   await db.query(
    {text:"INSERT INTO users(user_id,modify_date) VALUES($1,current_timestamp)",values:[userID]
-  }).catch(e=>{throw e}); 
- }
+  }).catch(
+   e=>{
+    if(/Key \(user_id\)=\(U[0-9,a-f]{32}\) already exists\./.test(e.detail)){
+     console.log("This user already exists. ignored")
+    }else{
+     throw e;
+    }
+ })
+
+}
 
  public async configureUser(userID:string,time:string,area:string){
 


### PR DESCRIPTION
## Resolved Issues ✨
- 一度ブロックして再度追加するとすでにユーザレコードがあるため主キーがuniqueとならずエラーが生じてコケていた

## Changes ⛏
- `already exists`なエラーは無視する仕様にした

