### PR TITLE
postbackに対してtextではなくdisplayTextを設定

### DIFF
--- a/src/messages/confirmNotificationClear.ts
+++ b/src/messages/confirmNotificationClear.ts
@@ -11,7 +11,7 @@ export default (): line.TemplateMessage => {
         {
           type: 'postback',
           label: 'はい',
-          text: 'はい',
+          displayText: 'はい',
           data: JSON.stringify({
             type: 'confirmNotificationClear',
             confirm: true,
@@ -20,7 +20,7 @@ export default (): line.TemplateMessage => {
         {
           type: 'postback',
           label: 'いいえ',
-          text: 'いいえ',
+          displayText: 'いいえ',
           data: JSON.stringify({
             type: 'confirmNotificationClear',
             confirm: false,

--- a/src/messages/confirmNotificationSettings.ts
+++ b/src/messages/confirmNotificationSettings.ts
@@ -14,7 +14,7 @@ export default (
         {
           type: 'postback',
           label: 'はい',
-          text: 'はい',
+          displayText: 'はい',
           data: JSON.stringify({
             type: 'confirmNotificationSettings',
             confirm: true,
@@ -25,7 +25,7 @@ export default (
         {
           type: 'postback',
           label: 'いいえ',
-          text: 'いいえ',
+          displayText: 'いいえ',
           data: JSON.stringify({
             type: 'confirmNotificationSettings',
             confirm: false,

--- a/src/messages/selectArea.ts
+++ b/src/messages/selectArea.ts
@@ -38,7 +38,7 @@ export default (): line.FlexMessage => {
             action: {
               type: 'postback',
               label: '大宝・大宝東・大宝西・金勝',
-              text: '大宝・大宝東・大宝西・金勝エリア',
+              displayText: '大宝・大宝東・大宝西・金勝エリア',
               data: JSON.stringify({
                 type: 'selectArea',
                 selectedAreaName: '大宝・大宝東・大宝西・金勝エリア',
@@ -57,7 +57,7 @@ export default (): line.FlexMessage => {
             action: {
               type: 'postback',
               label: '治田・治田東・治田西',
-              text: '治田・治田東・治田西エリア',
+              displayText: '治田・治田東・治田西エリア',
               data: JSON.stringify({
                 type: 'selectArea',
                 selectedAreaName: '治田・治田東・治田西エリア',
@@ -76,7 +76,7 @@ export default (): line.FlexMessage => {
             action: {
               type: 'postback',
               label: '葉山・葉山東',
-              text: '葉山・葉山東エリア',
+              displayText: '葉山・葉山東エリア',
               data: JSON.stringify({
                 type: 'selectArea',
                 selectedAreaName: '葉山・葉山東エリア',


### PR DESCRIPTION
## Issues ✨
- 通知を設定する過程で、不要な「メッセージが解釈できませんでした」エラーが出力されていた
- どうやらLINE側の仕様が変わった。 `postback` アクションに設定された　`text`に対しては `postback` イベントだけでなく `message` イベントも発火していた→登録外のtextを含むmessageだったのでエラーが出力されてしまった


## Changes ⛏
- [LINEのリファレンス](https://developers.line.biz/ja/reference/messaging-api/#postback-action)を参考に`text` プロパティを`displayText` プロパティで置き換えた


