### PR TITLE
proxy.envを.gitignoreする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .env
 cdk.out
+proxy.env


### PR DESCRIPTION
## Resolved Issues ✨
- `proxy.env`が `.gitignore`に載っていなかった

## Changes ⛏
- ignoreされてなければ、ignoreすればいいじゃない! 🧙 
